### PR TITLE
fix(grpcroute): use correct function in removal of grpc header route

### DIFF
--- a/pkg/plugin/grpcroute.go
+++ b/pkg/plugin/grpcroute.go
@@ -144,7 +144,7 @@ func (r *RpcPlugin) setGRPCHeaderRoute(rollout *v1alpha1.Rollout, headerRouting 
 				Name: headerRouting.Name,
 			},
 		}
-		return r.removeHTTPManagedRoutes(managedRouteList, gatewayAPIConfig)
+		return r.removeGRPCManagedRoutes(managedRouteList, gatewayAPIConfig)
 	}
 	ctx := context.TODO()
 	grpcRouteClient := r.GRPCRouteClient


### PR DESCRIPTION
surprising that no tests caught this (or anything for that matter) for the time that this copy/paste mistake was live... for 8 months.